### PR TITLE
chore: add assignee

### DIFF
--- a/create-jira/action.yaml
+++ b/create-jira/action.yaml
@@ -14,6 +14,8 @@ inputs:
     description: "Description of the issue"
   issuetype:
     description: "Name of the issue type"
+  assignee:
+    description: "Assignee of the issue"
   labels:
     description: "Labels for the issue. Comma separated."
   components:

--- a/create-jira/index.js
+++ b/create-jira/index.js
@@ -25,6 +25,7 @@ function main() {
     const issuetype = core.getInput('issuetype');
     const labels = core.getInput('labels');
     const components = core.getInput('components');
+    const assignee = core.getInput('assignee');
     const extraData = core.getInput('extra-data');
     const labelList = labels.split(",").filter(value => value != "")
     const componentList = components.split(",").filter(value => value != "")
@@ -35,6 +36,9 @@ function main() {
     }
     if (issuetype != "") {
       body["fields"]["issuetype"] = {"name": issuetype};
+    }
+    if (assignee != "") {
+      body["fields"]["assignee"] = {"name": assignee};
     }
     if (labelList.length != 0) {
       body["fields"]["labels"] = labelList;


### PR DESCRIPTION
aims to replace
```
    - name: Create JIRA ticket
      uses: mongodb/apix-action/create-jira@v4
      id: create
      with:
        project-key: CLOUDP
        summary: ...
        extra-data: |
          {
            "fields": {
              "assignee": {
                "name": "cloud-atlascli-escalation"
              },
              ...
```

with
```
    - name: Create JIRA ticket
      uses: mongodb/apix-action/create-jira@v4
      id: create
      with:
        project-key: CLOUDP
        summary: ...
        assignee: cloud-atlascli-escalation
```