### PR TITLE
chore: Expand dependabot-update-dist to cover comment-jira

### DIFF
--- a/.github/workflows/dependabot-update-dist.yaml
+++ b/.github/workflows/dependabot-update-dist.yaml
@@ -34,15 +34,18 @@ jobs:
         cd ../create-jira
         npm ci
         npm run build
+        cd ../comment-jira
+        npm ci
+        npm run build
     - name: Commit dist
       run: |
         echo "Changes to dist files:"
-        if git diff --exit-code --name-status -- verify-changed-files/dist create-jira/dist; then
+        if git diff --exit-code --name-status -- verify-changed-files/dist create-jira/dist comment-jira/dist; then
           echo "No changes to dist folders"
         else 
           git config --global user.name "${{ steps.app-token.outputs.user-name }}"
           git config --global user.email "${{ steps.app-token.outputs.user-email }}"
-          git add verify-changed-files/dist create-jira/dist
+          git add verify-changed-files/dist create-jira/dist comment-jira/dist
           git commit -m "chore: update dist folders"
           git push origin "${{ github.head_ref }}"
         fi


### PR DESCRIPTION
`dependabot-update-dist.yaml` auto updated the dist files for `verifiy-changed-files` and `create-jira` but didn't cover `comment-jira`. This pr adds coverage for that action to auto-unblock dependabot bumps on comment-jira.