### PR TITLE
POC Loading secrets from 1Password

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,19 @@ jobs:
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
           APP_ID: "op://APIx DevTools/APIx Github Bot/App ID"
-          APP_PEM: "op://APIx DevTools/APIx Github Bot/app.pem"
+          APP_SECRET: "op://APIx DevTools/APIx Github Bot/App Secret"
+      - id: decode-app-secret
+        run: |
+          echo "APP_PEM=$(echo "${{ steps.load-secrets.outputs.APP_SECRET }}" | base64 -d | openssl pkey -inform DER -outform PEM)" >> "$GITHUB_OUTPUT"
+      - name: Set Apix Bot token
+        id: app-token
+        uses: mongodb/apix-action/token@8549161120ce38b1e132ff833302a0ecbde58038
+        with:
+          app-id: ${{ steps.load-secrets.outputs.APP_ID }}
+          private-key: ${{ steps.decode-app-secret.outputs.APP_PEM }}
       - run: |
-          echo "App ID=$(echo "${{ steps.load-secrets.outputs.APP_ID }}" | wc -m) chars"
+          rm -rf app.pem
+      - env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh pr comment "${{ github.event.pull_request.html_url }}" --body "Test comment from workflow"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,11 @@ jobs:
           APP_SECRET: "op://APIx DevTools/APIx Github Bot/App Secret"
       - id: decode-app-secret
         run: |
-          echo "APP_PEM=$(echo "${{ steps.load-secrets.outputs.APP_SECRET }}" | base64 -d | openssl pkey -inform DER -outform PEM)" >> "$GITHUB_OUTPUT"
+          {
+            echo 'APP_PEM<<EOF'
+            echo "${{ steps.load-secrets.outputs.APP_SECRET }}" | base64 -d | openssl pkey -inform DER -outform PEM
+            echo EOF
+          } >> "$GITHUB_ENV"
       - name: Set Apix Bot token
         id: app-token
         uses: mongodb/apix-action/token@8549161120ce38b1e132ff833302a0ecbde58038

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ jobs:
             echo 'APP_PEM<<EOF'
             echo "${{ steps.load-secrets.outputs.APP_SECRET }}" | base64 -d | openssl pkey -inform DER -outform PEM
             echo EOF
-          } >> "$GITHUB_ENV"
+          } >> "$GITHUB_OUTPUT"
       - name: Set Apix Bot token
         id: app-token
         uses: mongodb/apix-action/token@8549161120ce38b1e132ff833302a0ecbde58038

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,18 @@
+name: Test
+on:
+  pull_request:
+jobs:
+  transition-jira-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+        with:
+          config: ${{ vars.PERMISSIONS_CONFIG }}
+      - uses: 1password/load-secrets-action@v4
+        id: load-secrets
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          APP_ID: "op://APIx DevTools/APIx Github Bot/App ID"
+          APP_PEM: "op://APIx DevTools/APIx Github Bot/app.pem"
+      - run: |
+          echo "App ID=${{ steps.load-secrets.outputs.APP_ID }}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,7 @@ name: Test
 on:
   pull_request:
 jobs:
-  transition-jira-test:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: GitHubSecurityLab/actions-permissions/monitor@v1
@@ -15,4 +15,4 @@ jobs:
           APP_ID: "op://APIx DevTools/APIx Github Bot/App ID"
           APP_PEM: "op://APIx DevTools/APIx Github Bot/app.pem"
       - run: |
-          echo "App ID=${{ steps.load-secrets.outputs.APP_ID }}"
+          echo "App ID=$(echo "${{ steps.load-secrets.outputs.APP_ID }}" | wc -m) chars"


### PR DESCRIPTION
## POC: Load Secrets Directly from 1Password

### Context

[Automata](https://github.com/mongodb-labs/automata) is a declarative CI automation hub we're evaluating that relies on Argo Events + NATS JetStream to receive and react to GitHub webhooks. Before committing to that infrastructure, this POC explores a simpler path.

### What This Tests

If we can load GitHub App credentials directly from 1Password at workflow runtime, we may not need Automata at all for our use case. The proposed model:
- One **1Password Service Account Token** per repo (`OP_SERVICE_ACCOUNT_TOKEN`)
- The `1password/load-secrets-action` pulls App ID + private key from the 1Password vault at runtime
- Shared workflows defined here and distributed via [`peter-evans/create-pull-request`](https://github.com/peter-evans/create-pull-request) and [reusable workflows](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows)

The test workflow:
1. Loads App ID and DER-encoded private key from `op://APIx DevTools/APIx Github Bot`
2. Decodes the key (base64 DER → PEM)
3. Generates a GitHub App token via `mongodb/apix-action/token`
4. Posts a comment on this PR as the bot to confirm the full flow works

### Conclusion

We'd need only one secret per repo and no Argo Events, no NATS, no Automata deployment. The full distribution flow would look like this:

1. Someone opens a PR against this repo (`mongodb/apix-action`) adding a workflow meant to be shared across repos. The file includes sync headers indicating the target repos:
   ```yaml
   # sync -> 10gen/cobra2snooty
   # sync -> mongodb/mongodb-atlas-local
   on:
     push:
   jobs:
     # ...
   ```
2a. After the PR is merged, a GitHub Action in this repo detects whether a workflow file was added, updated, or deleted, and opens corresponding PRs on each target repo using [`peter-evans/create-pull-request`](https://github.com/peter-evans/create-pull-request), authenticated via the bot token this POC validates.
2b. Alternatively we could have one github action on each repo pulling from mongodb/apix-action and checking which workflows should be updated on a daily cron
3. Approving those PRs follows the normal dependency upgrade process already in place for each repo.
