### PR TITLE
feat: add atlas-local-lib-py as a Jira sync target

### DIFF
--- a/.github/workflows/_create-jira.yaml
+++ b/.github/workflows/_create-jira.yaml
@@ -53,7 +53,7 @@ jobs:
         id: config
         run: |
           case "${{ github.repository }}" in
-            */mongodb-atlas-local|*/atlas-local-lib|*/atlas-local-cli|*/atlas-local-lib-js)
+            */mongodb-atlas-local|*/atlas-local-lib|*/atlas-local-cli|*/atlas-local-lib-js|*/atlas-local-lib-py)
               echo "component=local-atlas-experience" >> "$GITHUB_OUTPUT"
               echo "fix_version=Not Applicable" >> "$GITHUB_OUTPUT"
               ;;

--- a/.github/workflows/_dependabot-jira.yaml
+++ b/.github/workflows/_dependabot-jira.yaml
@@ -24,7 +24,7 @@ jobs:
         id: config
         run: |
           case "${{ github.repository }}" in
-            */atlas-local-lib|*/atlas-local-cli|*/atlas-local-lib-js)
+            */atlas-local-lib|*/atlas-local-cli|*/atlas-local-lib-js|*/atlas-local-lib-py)
               echo "component=local-atlas-experience" >> "$GITHUB_OUTPUT"
               ;;
             *)

--- a/.github/workflows/_issue-opened.yaml
+++ b/.github/workflows/_issue-opened.yaml
@@ -24,7 +24,7 @@ jobs:
         id: config
         run: |
           case "${{ github.repository }}" in
-            */mongodb-atlas-local|*/atlas-local-lib|*/atlas-local-cli|*/atlas-local-lib-js)
+            */mongodb-atlas-local|*/atlas-local-lib|*/atlas-local-cli|*/atlas-local-lib-js|*/atlas-local-lib-py)
               echo "component=local-atlas-experience" >> "$GITHUB_OUTPUT"
               ;;
             *)

--- a/.github/workflows/close-jira.yaml
+++ b/.github/workflows/close-jira.yaml
@@ -1,6 +1,7 @@
 # sync -> mongodb/atlas-local-lib
 # sync -> mongodb/atlas-local-cli
 # sync -> mongodb-js/atlas-local-lib-js
+# sync -> mongodb/atlas-local-lib-py
 
 name: Auto Close Jira
 

--- a/.github/workflows/create-jira.yaml
+++ b/.github/workflows/create-jira.yaml
@@ -1,6 +1,7 @@
 # sync -> mongodb/atlas-local-lib
 # sync -> mongodb/atlas-local-cli
 # sync -> mongodb-js/atlas-local-lib-js
+# sync -> mongodb/atlas-local-lib-py
 # sync -> mongodb/mongodb-atlas-cli
 # sync -> mongodb/mongodb-atlas-local
 # sync -> mongodb-labs/cobra2snooty

--- a/.github/workflows/dependabot-jira.yaml
+++ b/.github/workflows/dependabot-jira.yaml
@@ -1,6 +1,7 @@
 # sync -> mongodb/atlas-local-lib
 # sync -> mongodb/atlas-local-cli
 # sync -> mongodb-js/atlas-local-lib-js
+# sync -> mongodb/atlas-local-lib-py
 
 name: Create Jira Ticket for Dependabot PRs
 

--- a/.github/workflows/issue-closed.yaml
+++ b/.github/workflows/issue-closed.yaml
@@ -2,6 +2,7 @@
 # sync -> mongodb/atlas-local-lib
 # sync -> mongodb/atlas-local-cli
 # sync -> mongodb-js/atlas-local-lib-js
+# sync -> mongodb/atlas-local-lib-py
 # sync -> mongodb-labs/cobra2snooty
 
 name: Close Jira Ticket on Issue Close

--- a/.github/workflows/issue-opened.yaml
+++ b/.github/workflows/issue-opened.yaml
@@ -2,6 +2,7 @@
 # sync -> mongodb/atlas-local-lib
 # sync -> mongodb/atlas-local-cli
 # sync -> mongodb-js/atlas-local-lib-js
+# sync -> mongodb/atlas-local-lib-py
 # sync -> mongodb-labs/cobra2snooty
 
 name: Create Jira Ticket for New Issues

--- a/.github/workflows/issue-reopened.yaml
+++ b/.github/workflows/issue-reopened.yaml
@@ -2,6 +2,7 @@
 # sync -> mongodb/atlas-local-lib
 # sync -> mongodb/atlas-local-cli
 # sync -> mongodb-js/atlas-local-lib-js
+# sync -> mongodb/atlas-local-lib-py
 # sync -> mongodb-labs/cobra2snooty
 
 name: Reopen Jira Ticket on Issue Reopen


### PR DESCRIPTION
## Summary

_Jira ticket:_ [CLOUDP-426397](https://jira.mongodb.org/browse/CLOUDP-426397)

- Registers `mongodb/atlas-local-lib-py` as a sync target in the 6 caller workflows (`create-jira`, `close-jira`, `dependabot-jira`, `issue-opened`, `issue-closed`, `issue-reopened`), matching the existing entries for `atlas-local-lib`, `atlas-local-cli`, and `atlas-local-lib-js`.
Adds `*/atlas-local-lib-py` to the repo-classification case in `_create-jira.yaml`, `_dependabot-jira.yaml`, and `_issue-opened.yaml` so PRs/issues from the new repo get the `local-atlas-experience` Jira component.

**Related:** these workflows are introduced on `atlas-local-lib-py` in [mongodb/atlas-local-lib-py#4](https://github.com/mongodb/atlas-local-lib-py/pull/4/changes).

## Test plan

- [ ] Confirm a PR/issue opened in `atlas-local-lib-py` creates a Jira ticket with component `local-atlas-experience`.