### PR TITLE
feat(sync): derive workflow owners

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -10,6 +10,9 @@ jobs:
   sync:
     name: Sync workflows to repositories
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        owner: [mongodb, mongodb-js, mongodb-labs]
     steps:
       - name: Set APIX bot token
         id: app-token
@@ -17,6 +20,7 @@ jobs:
         with:
           app-id: ${{ secrets.APIXBOT_APP_ID }}
           private-key: ${{ secrets.APIXBOT_APP_PEM }}
+          owner: ${{ matrix.owner }}
       - name: Checkout
         uses: actions/checkout@v7.0.1
         with:
@@ -28,5 +32,6 @@ jobs:
       - name: Sync workflows
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SYNC_OWNER: ${{ matrix.owner }}
           WORKFLOW_DIRECTORY: .github/workflows
         run: just sync

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -7,12 +7,35 @@ permissions:
   contents: read
 
 jobs:
+  build:
+    name: Build sync binary
+    runs-on: ubuntu-latest
+    outputs:
+      owners: ${{ steps.owners.outputs.owners }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install just
+        run: cargo install just --locked
+      - name: Build
+        run: just build
+      - name: Find owners
+        id: owners
+        run: echo "owners=$(just owners)" >> "$GITHUB_OUTPUT"
+      - name: Upload sync binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: sync-binary
+          path: bin/sync
   sync:
     name: Sync workflows to repositories
+    needs: build
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        owner: [mongodb, mongodb-js, mongodb-labs]
+        owner: ${{ fromJSON(needs.build.outputs.owners) }}
     steps:
       - name: Set APIX bot token
         id: app-token
@@ -29,9 +52,16 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
       - name: Install just
         run: cargo install just --locked
+      - name: Download sync binary
+        uses: actions/download-artifact@v4
+        with:
+          name: sync-binary
+          path: bin
       - name: Sync workflows
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           SYNC_OWNER: ${{ matrix.owner }}
           WORKFLOW_DIRECTORY: .github/workflows
-        run: just sync
+        run: |
+          chmod +x bin/sync
+          just sync

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -25,7 +25,7 @@ jobs:
         id: owners
         run: echo "owners=$(just owners)" >> "$GITHUB_OUTPUT"
       - name: Upload sync binary
-        uses: actions/upload-artifact@v4
+  uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: sync-binary
           path: bin/sync

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Install just
         run: cargo install just --locked
       - name: Download sync binary
-        uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: sync-binary
           path: bin

--- a/justfile
+++ b/justfile
@@ -11,7 +11,10 @@ build-debug:
 	mkdir -p bin
 	cp sync/target/debug/{{binary}} bin/{{binary}}
 
-sync *args: build
+owners:
+	./bin/{{binary}} owners
+
+sync *args:
 	./bin/{{binary}} {{args}}
 
 sync-with-gh-token *args:

--- a/sync/Cargo.lock
+++ b/sync/Cargo.lock
@@ -1968,6 +1968,7 @@ dependencies = [
  "nutype",
  "octocrab",
  "redacted",
+ "serde_json",
  "thiserror",
  "tokio",
  "tracing",

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -11,6 +11,7 @@ non-empty-string = "0.2.6"
 nutype = "0.7.0"
 octocrab = "0.54.0"
 redacted = "0.2.0"
+serde_json = "1.0.140"
 thiserror = "2.0.19"
 tokio = { version = "1.53.1", features = ["full"] }
 tracing = "0.1.44"

--- a/sync/src/args.rs
+++ b/sync/src/args.rs
@@ -16,6 +16,9 @@ pub struct Args {
 
     #[arg(long, env = "WORKFLOW_DIRECTORY")]
     pub workflows_directory: Option<PathBuf>,
+
+    #[arg(long, env = "SYNC_OWNER")]
+    pub owner: Option<String>,
 }
 
 // Parse and redact the GitHub token supplied through the CLI or environment.

--- a/sync/src/args.rs
+++ b/sync/src/args.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use redacted::FullyRedacted;
 
 use crate::shared::{GithubToken, GithubTokenError};
@@ -10,15 +10,24 @@ use crate::shared::{GithubToken, GithubTokenError};
 #[derive(Parser, Debug)]
 #[command(version, about)]
 pub struct Args {
+    #[command(subcommand)]
+    pub command: Option<Command>,
+
     #[arg(long, env = "GH_TOKEN")]
     #[arg(value_parser = parse_github_token)]
-    pub token: FullyRedacted<GithubToken>,
+    pub token: Option<FullyRedacted<GithubToken>>,
 
     #[arg(long, env = "WORKFLOW_DIRECTORY")]
     pub workflows_directory: Option<PathBuf>,
 
     #[arg(long, env = "SYNC_OWNER")]
     pub owner: Option<String>,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    /// Print owners declared by syncable workflows as a JSON array.
+    Owners,
 }
 
 // Parse and redact the GitHub token supplied through the CLI or environment.

--- a/sync/src/main.rs
+++ b/sync/src/main.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
 
-use crate::args::Args;
+use crate::args::{Args, Command};
 
 mod args;
 mod labels;
@@ -30,6 +30,17 @@ async fn main() -> Result<()> {
     let args = Args::parse();
     let workflows_directory = args.workflows_directory_or_default()?;
 
+    if matches!(args.command, Some(Command::Owners)) {
+        let owners = scan::scan(workflows_directory)
+            .await?
+            .into_iter()
+            .flat_map(|workflow| workflow.sync.into_iter().map(|repository| repository.owner))
+            .map(|owner| owner.to_string())
+            .collect::<std::collections::BTreeSet<_>>();
+        println!("{}", serde_json::to_string(&owners)?);
+        return Ok(());
+    }
+
     // Find source workflows that declare repositories to sync.
     info!(directory = %workflows_directory.display(), "scanning workflows");
 
@@ -53,11 +64,12 @@ async fn main() -> Result<()> {
         .join("targets");
 
     // Check out all target repositories and write their applicable workflows.
-    sync::sync(&workflows, targets_directory.clone(), args.token.clone()).await?;
+    let token = args.token.context("GitHub token is required for sync")?;
+    sync::sync(&workflows, targets_directory.clone(), token.clone()).await?;
     info!("sync complete");
 
     // Ensure every target has `apix-action`, which the PR phase uses to find old generated PRs.
-    labels::ensure(&workflows, args.token.clone()).await?;
+    labels::ensure(&workflows, token.clone()).await?;
     info!("labels are present in all repositories");
 
     // Only create pull requests for repositories whose working tree changed.
@@ -77,7 +89,7 @@ async fn main() -> Result<()> {
         &workflows,
         repositories_needing_pr,
         targets_directory,
-        args.token,
+        token,
     )
     .await?;
 

--- a/sync/src/main.rs
+++ b/sync/src/main.rs
@@ -33,7 +33,19 @@ async fn main() -> Result<()> {
     // Find source workflows that declare repositories to sync.
     info!(directory = %workflows_directory.display(), "scanning workflows");
 
-    let workflows = scan::scan(workflows_directory).await?;
+    let owner = args.owner.as_deref();
+    let workflows = scan::scan(workflows_directory)
+        .await?
+        .into_iter()
+        .filter_map(|mut workflow| {
+            if let Some(owner) = owner {
+                workflow
+                    .sync
+                    .retain(|repository| repository.owner.as_str() == owner);
+            }
+            (!workflow.sync.is_empty()).then_some(workflow)
+        })
+        .collect::<Vec<_>>();
     info!(workflows = workflows.len(), "found syncable workflows");
 
     let targets_directory = env::current_dir()


### PR DESCRIPTION
## Summary

GitHub App installation tokens are scoped to one owner and cannot be used across multiple owners. The sync workflow currently hardcodes all owners into one matrix, while token generation must happen per owner.

This change derives owners from workflow sync metadata and runs one matrix job per owner, generating a matching token for each job.

## Changes

- Add `sync owners` subcommand returning sorted JSON owners
- Add `just owners` target
- Build sync binary once and reuse it for owner discovery and matrix sync jobs
- Replace hardcoded owner list

## Validation

- `cargo fmt`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets`
- `just build && just owners`