### PR TITLE
Sync Dependabot auto-merge to mongodb-atlas-cli

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -1,4 +1,5 @@
 # sync -> mongodb/atlas-local-lib-py
+# sync -> mongodb/mongodb-atlas-cli
 
 name: Auto merge dependabot prs
 


### PR DESCRIPTION
## Summary
- Add mongodb/mongodb-atlas-cli as dependabot auto-merge workflow sync target

## Validation
- git diff --check
- Did not run just sync so I can test our github action