### PR TITLE
ci: fix dependabot auto-merge permissions

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -20,13 +20,19 @@ jobs:
     - uses: GitHubSecurityLab/actions-permissions/monitor@v1
       with:
         config: ${{ vars.PERMISSIONS_CONFIG }}
+    - name: Set APIX bot token
+      id: app-token
+      uses: mongodb/apix-action/token@8549161120ce38b1e132ff833302a0ecbde58038
+      with:
+        app-id: ${{ secrets.APIXBOT_APP_ID }}
+        private-key: ${{ secrets.APIXBOT_APP_PEM }}
     - name: Approve PR
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
       run: |
         gh pr review "${{ github.event.pull_request.html_url }}" --approve
     - name: Auto merge PR
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
       run: |
         gh pr merge "${{ github.event.pull_request.html_url }}" --auto --squash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,4 +2,4 @@
 
 Add `# sync -> owner/repository` to workflow under `.github/workflows/` to add target. Remove header to stop syncing target.
 
-Run `just sync-with-gh-token` locally to propagate changes and open generated PRs. GitHub Actions sync trigger is WIP.
+Merge workflow changes to `main`, then manually run the `Sync workflows` GitHub Action to propagate changes and open generated PRs.


### PR DESCRIPTION
## Summary
- use APIx bot token for Dependabot PR approval and auto-merge
- update workflow sync instructions to use GitHub Action after merging to main

## Verification
- actionlint .github/workflows/dependabot-auto-merge.yaml
- git diff --check origin/main...HEAD