### PR TITLE
ci: pin action refs to commit SHAs

### DIFF
--- a/.github/workflows/_close-jira.yaml
+++ b/.github/workflows/_close-jira.yaml
@@ -12,10 +12,10 @@ jobs:
     name: Close Jira ticket
     runs-on: ubuntu-latest
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
-      - uses: 1password/load-secrets-action@v5
+      - uses: 1password/load-secrets-action@8a61560e8e31bb0596b64b0df75696368c948c04 # v5
         id: load-secrets
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
@@ -39,7 +39,7 @@ jobs:
           JIRA_KEY=$(gh pr view "$URL" --comments | grep 'was created for internal tracking' | grep -oE 'CLOUDP-[0-9]+' | head -1)
           echo "key=$JIRA_KEY" >> "$GITHUB_OUTPUT"
       - name: Transition Jira ticket
-        uses: mongodb/apix-action/transition-jira@v14
+        uses: mongodb/apix-action/transition-jira@8549161120ce38b1e132ff833302a0ecbde58038 # v14
         with:
           token: ${{ steps.load-secrets.outputs.JIRA_API_TOKEN }}
           issue-key: ${{ steps.find.outputs.key }}

--- a/.github/workflows/_close-jira.yaml
+++ b/.github/workflows/_close-jira.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
-      - uses: 1password/load-secrets-action@8a61560e8e31bb0596b64b0df75696368c948c04 # v5
+      - uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5
         id: load-secrets
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/_create-jira.yaml
+++ b/.github/workflows/_create-jira.yaml
@@ -12,10 +12,10 @@ jobs:
     name: Create Jira ticket
     runs-on: ubuntu-latest
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
-      - uses: 1password/load-secrets-action@v5
+      - uses: 1password/load-secrets-action@8a61560e8e31bb0596b64b0df75696368c948c04 # v5
         id: load-secrets
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
@@ -31,12 +31,12 @@ jobs:
           } >> "$GITHUB_OUTPUT"
       - name: Set Apix Bot token
         id: app-token
-        uses: mongodb/apix-action/token@8549161120ce38b1e132ff833302a0ecbde58038
+        uses: mongodb/apix-action/token@8549161120ce38b1e132ff833302a0ecbde58038 # v14
         with:
           app-id: ${{ steps.load-secrets.outputs.APP_ID }}
           private-key: ${{ steps.decode-app-secret.outputs.APP_PEM }}
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
@@ -67,7 +67,7 @@ jobs:
               ;;
           esac
       - name: Create Jira ticket
-        uses: mongodb/apix-action/create-jira@v14
+        uses: mongodb/apix-action/create-jira@8549161120ce38b1e132ff833302a0ecbde58038 # v14
         id: create
         with:
           token: ${{ steps.load-secrets.outputs.JIRA_API_TOKEN }}
@@ -86,7 +86,7 @@ jobs:
               }
             }
       - name: Add comment
-        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           token: ${{ steps.app-token.outputs.token }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/_create-jira.yaml
+++ b/.github/workflows/_create-jira.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
-      - uses: 1password/load-secrets-action@8a61560e8e31bb0596b64b0df75696368c948c04 # v5
+      - uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5
         id: load-secrets
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/_dependabot-jira.yaml
+++ b/.github/workflows/_dependabot-jira.yaml
@@ -12,10 +12,10 @@ jobs:
     name: Create Jira ticket
     runs-on: ubuntu-latest
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
-      - uses: 1password/load-secrets-action@v5
+      - uses: 1password/load-secrets-action@8a61560e8e31bb0596b64b0df75696368c948c04 # v5
         id: load-secrets
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
@@ -32,7 +32,7 @@ jobs:
               ;;
           esac
       - name: Create Jira ticket
-        uses: mongodb/apix-action/create-jira@v14
+        uses: mongodb/apix-action/create-jira@8549161120ce38b1e132ff833302a0ecbde58038 # v14
         id: create
         with:
           token: ${{ steps.load-secrets.outputs.JIRA_API_TOKEN }}
@@ -51,7 +51,7 @@ jobs:
               }
             }
       - name: Add comment
-        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           token: ${{ github.token }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/_dependabot-jira.yaml
+++ b/.github/workflows/_dependabot-jira.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
-      - uses: 1password/load-secrets-action@8a61560e8e31bb0596b64b0df75696368c948c04 # v5
+      - uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5
         id: load-secrets
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/_issue-closed.yaml
+++ b/.github/workflows/_issue-closed.yaml
@@ -12,10 +12,10 @@ jobs:
     name: Close Jira ticket
     runs-on: ubuntu-latest
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
-      - uses: 1password/load-secrets-action@v5
+      - uses: 1password/load-secrets-action@8a61560e8e31bb0596b64b0df75696368c948c04 # v5
         id: load-secrets
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
@@ -28,7 +28,7 @@ jobs:
           JIRA_KEY=$(gh issue view ${{ github.event.issue.number }} --comments --repo ${{ github.repository }} | grep 'was created for internal tracking' | grep -oE 'CLOUDP-[0-9]+' | head -1)
           echo "key=$JIRA_KEY" >> "$GITHUB_OUTPUT"
       - name: Close Jira ticket
-        uses: mongodb/apix-action/transition-jira@v14
+        uses: mongodb/apix-action/transition-jira@8549161120ce38b1e132ff833302a0ecbde58038 # v14
         with:
           token: ${{ steps.load-secrets.outputs.JIRA_API_TOKEN }}
           issue-key: ${{ steps.find.outputs.key }}

--- a/.github/workflows/_issue-closed.yaml
+++ b/.github/workflows/_issue-closed.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
-      - uses: 1password/load-secrets-action@8a61560e8e31bb0596b64b0df75696368c948c04 # v5
+      - uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5
         id: load-secrets
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/_issue-opened.yaml
+++ b/.github/workflows/_issue-opened.yaml
@@ -12,10 +12,10 @@ jobs:
     name: Create Jira ticket
     runs-on: ubuntu-latest
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
-      - uses: 1password/load-secrets-action@v5
+      - uses: 1password/load-secrets-action@8a61560e8e31bb0596b64b0df75696368c948c04 # v5
         id: load-secrets
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
@@ -32,7 +32,7 @@ jobs:
               ;;
           esac
       - name: Create Jira ticket
-        uses: mongodb/apix-action/create-jira@v14
+        uses: mongodb/apix-action/create-jira@8549161120ce38b1e132ff833302a0ecbde58038 # v14
         id: create
         with:
           token: ${{ steps.load-secrets.outputs.JIRA_API_TOKEN }}
@@ -51,7 +51,7 @@ jobs:
               }
             }
       - name: Add comment
-        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
         with:
           token: ${{ github.token }}
           issue-number: ${{ github.event.issue.number }}

--- a/.github/workflows/_issue-opened.yaml
+++ b/.github/workflows/_issue-opened.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
-      - uses: 1password/load-secrets-action@8a61560e8e31bb0596b64b0df75696368c948c04 # v5
+      - uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5
         id: load-secrets
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/_issue-reopened.yaml
+++ b/.github/workflows/_issue-reopened.yaml
@@ -12,10 +12,10 @@ jobs:
     name: Reopen Jira ticket
     runs-on: ubuntu-latest
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
-      - uses: 1password/load-secrets-action@v5
+      - uses: 1password/load-secrets-action@8a61560e8e31bb0596b64b0df75696368c948c04 # v5
         id: load-secrets
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
@@ -28,7 +28,7 @@ jobs:
           JIRA_KEY=$(gh issue view ${{ github.event.issue.number }} --comments --repo ${{ github.repository }} | grep 'was created for internal tracking' | grep -oE 'CLOUDP-[0-9]+' | head -1)
           echo "key=$JIRA_KEY" >> "$GITHUB_OUTPUT"
       - name: Reopen Jira ticket
-        uses: mongodb/apix-action/transition-jira@v14
+        uses: mongodb/apix-action/transition-jira@8549161120ce38b1e132ff833302a0ecbde58038 # v14
         with:
           token: ${{ steps.load-secrets.outputs.JIRA_API_TOKEN }}
           issue-key: ${{ steps.find.outputs.key }}

--- a/.github/workflows/_issue-reopened.yaml
+++ b/.github/workflows/_issue-reopened.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
-      - uses: 1password/load-secrets-action@8a61560e8e31bb0596b64b0df75696368c948c04 # v5
+      - uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5
         id: load-secrets
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/ci-comment-jira.yaml
+++ b/.github/workflows/ci-comment-jira.yaml
@@ -9,12 +9,12 @@ jobs:
   comment-jira-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
       - name: Checkout repository
-        uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
             node-version-file: comment-jira/package.json
       - name: install dependencies
@@ -41,12 +41,12 @@ jobs:
   comment-jira-unit-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
       - name: Checkout repository
-        uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
             node-version-file: comment-jira/package.json
       - name: install dependencies
@@ -60,11 +60,11 @@ jobs:
   comment-jira-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Write inline Nginx config
         run: |
           cat <<EOF > nginx.conf
@@ -114,4 +114,4 @@ jobs:
           comment: |
             Test comment from GitHub Actions
             with multiple lines
-          api-base: http://localhost:55000 
+          api-base: http://localhost:55000

--- a/.github/workflows/ci-create-jira.yaml
+++ b/.github/workflows/ci-create-jira.yaml
@@ -11,12 +11,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
       - name: Checkout repository
-        uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
             node-version-file: create-jira/package.json
       - name: install dependencies
@@ -45,12 +45,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
       - name: Checkout repository
-        uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
             node-version-file: create-jira/package.json
       - name: install dependencies
@@ -66,11 +66,11 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Write inline Nginx config
         run: |
           cat <<EOF > nginx.conf

--- a/.github/workflows/ci-dependabot-update-dist.yaml
+++ b/.github/workflows/ci-dependabot-update-dist.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
       with:
         config: ${{ vars.PERMISSIONS_CONFIG }}
-    - uses: 1password/load-secrets-action@8a61560e8e31bb0596b64b0df75696368c948c04 # v5
+    - uses: 1password/load-secrets-action@e544b780808654ba8ceba5fb2fe2897103d92ff4 # v5
       id: load-secrets
       env:
         OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/ci-dependabot-update-dist.yaml
+++ b/.github/workflows/ci-dependabot-update-dist.yaml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+    - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
       with:
         config: ${{ vars.PERMISSIONS_CONFIG }}
-    - uses: 1password/load-secrets-action@v5
+    - uses: 1password/load-secrets-action@8a61560e8e31bb0596b64b0df75696368c948c04 # v5
       id: load-secrets
       env:
         OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
@@ -27,17 +27,17 @@ jobs:
         } >> "$GITHUB_OUTPUT"
     - name: Set Apix Bot token
       id: app-token
-      uses: mongodb/apix-action/token@8549161120ce38b1e132ff833302a0ecbde58038
+      uses: mongodb/apix-action/token@8549161120ce38b1e132ff833302a0ecbde58038 # v14
       with:
         app-id: ${{ steps.load-secrets.outputs.APP_ID }}
         private-key: ${{ steps.decode-app-secret.outputs.APP_PEM }}
     - name: Checkout code
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:
         ref: ${{ github.head_ref }}
         token: ${{ steps.app-token.outputs.token }}
         fetch-depth: 0
-    - uses: actions/setup-node@v7
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
       with:
         node-version-file: 'create-jira/package.json'
     - run: |

--- a/.github/workflows/ci-find-jira.yaml
+++ b/.github/workflows/ci-find-jira.yaml
@@ -9,11 +9,11 @@ jobs:
   find-jira-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Write inline Nginx config
         run: |
           cat <<EOF > nginx.conf
@@ -61,4 +61,3 @@ jobs:
           token: test
           jql: QUERY
           api-base: http://localhost:55000
-          

--- a/.github/workflows/ci-transition-jira.yaml
+++ b/.github/workflows/ci-transition-jira.yaml
@@ -9,11 +9,11 @@ jobs:
   transition-jira-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Write inline Nginx config
         run: |
           cat <<EOF > nginx.conf
@@ -63,4 +63,3 @@ jobs:
           transition-id: TEST
           resolution: TEST
           api-base: http://localhost:55000
-          

--- a/.github/workflows/ci-verify-changed-files.yaml
+++ b/.github/workflows/ci-verify-changed-files.yaml
@@ -13,12 +13,12 @@ jobs:
     name: Test Verify Changed Files Action
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0  # Full git history for comparisons
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '20'
           cache: 'npm'
@@ -79,12 +79,12 @@ jobs:
     name: Verify dist files are updated
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0  # Full git history for comparisons
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '20'
 

--- a/.github/workflows/close-jira.yaml
+++ b/.github/workflows/close-jira.yaml
@@ -17,5 +17,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    uses: mongodb/apix-action/.github/workflows/_close-jira.yaml@main
+    uses: mongodb/apix-action/.github/workflows/_close-jira.yaml@9ce9e6205a14af111352430e9f9adbea1c75230b # main
     secrets: inherit

--- a/.github/workflows/create-jira.yaml
+++ b/.github/workflows/create-jira.yaml
@@ -20,5 +20,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: mongodb/apix-action/.github/workflows/_create-jira.yaml@main
+    uses: mongodb/apix-action/.github/workflows/_create-jira.yaml@9ce9e6205a14af111352430e9f9adbea1c75230b # main
     secrets: inherit

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
-    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+    - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
       with:
         config: ${{ vars.PERMISSIONS_CONFIG }}
     - name: Set APIX bot token
       id: app-token
-      uses: mongodb/apix-action/token@8549161120ce38b1e132ff833302a0ecbde58038
+      uses: mongodb/apix-action/token@8549161120ce38b1e132ff833302a0ecbde58038 # v14
       with:
         app-id: ${{ secrets.APIXBOT_APP_ID }}
         private-key: ${{ secrets.APIXBOT_APP_PEM }}

--- a/.github/workflows/dependabot-jira.yaml
+++ b/.github/workflows/dependabot-jira.yaml
@@ -17,5 +17,5 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: mongodb/apix-action/.github/workflows/_dependabot-jira.yaml@main
+    uses: mongodb/apix-action/.github/workflows/_dependabot-jira.yaml@9ce9e6205a14af111352430e9f9adbea1c75230b # main
     secrets: inherit

--- a/.github/workflows/issue-closed.yaml
+++ b/.github/workflows/issue-closed.yaml
@@ -18,5 +18,5 @@ jobs:
     permissions:
       contents: read
       issues: read
-    uses: mongodb/apix-action/.github/workflows/_issue-closed.yaml@main
+    uses: mongodb/apix-action/.github/workflows/_issue-closed.yaml@9ce9e6205a14af111352430e9f9adbea1c75230b # main
     secrets: inherit

--- a/.github/workflows/issue-opened.yaml
+++ b/.github/workflows/issue-opened.yaml
@@ -18,5 +18,5 @@ jobs:
     permissions:
       contents: read
       issues: write
-    uses: mongodb/apix-action/.github/workflows/_issue-opened.yaml@main
+    uses: mongodb/apix-action/.github/workflows/_issue-opened.yaml@9ce9e6205a14af111352430e9f9adbea1c75230b # main
     secrets: inherit

--- a/.github/workflows/issue-reopened.yaml
+++ b/.github/workflows/issue-reopened.yaml
@@ -18,5 +18,5 @@ jobs:
     permissions:
       contents: read
       issues: read
-    uses: mongodb/apix-action/.github/workflows/_issue-reopened.yaml@main
+    uses: mongodb/apix-action/.github/workflows/_issue-reopened.yaml@9ce9e6205a14af111352430e9f9adbea1c75230b # main
     secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,11 +10,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      - uses: GitHubSecurityLab/actions-permissions/monitor@bf82d13b9b10051d224345ab9184f5ede0a94289 # v1
         with:
           config: ${{ vars.PERMISSIONS_CONFIG }}
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - run: |
           gh release create ${{ github.ref_name }} --generate-notes
         env:

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -14,9 +14,9 @@ jobs:
       owners: ${{ steps.owners.outputs.owners }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
       - name: Install just
         run: cargo install just --locked
       - name: Build
@@ -42,13 +42,13 @@ jobs:
           printf '[]\n' > "sync-prs-${{ matrix.owner }}.json"
       - name: Set APIX bot token
         id: app-token
-        uses: mongodb/apix-action/token@8549161120ce38b1e132ff833302a0ecbde58038
+        uses: mongodb/apix-action/token@8549161120ce38b1e132ff833302a0ecbde58038 # v14
         with:
           app-id: ${{ secrets.APIXBOT_APP_ID }}
           private-key: ${{ secrets.APIXBOT_APP_PEM }}
           owner: ${{ matrix.owner }}
       - name: Checkout
-        uses: actions/checkout@v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ steps.app-token.outputs.token }}
       - name: Download sync binary


### PR DESCRIPTION
## Summary

- Pin GitHub Actions and reusable workflows to immutable 40-character commit SHAs.
- Preserve source versions or refs in comments for Dependabot and reviewability.

## Version provenance

| Action | Source ref | Pinned commit |
| --- | --- | --- |
| [actions/checkout](https://github.com/actions/checkout) | [v7 tag](https://github.com/actions/checkout/tree/v7) | [`3d3c42e5`](https://github.com/actions/checkout/commit/3d3c42e5aac5ba805825da76410c181273ba90b1) |
| [actions/setup-node](https://github.com/actions/setup-node) | [v7 tag](https://github.com/actions/setup-node/tree/v7) | [`82076278`](https://github.com/actions/setup-node/commit/820762786026740c76f36085b0efc47a31fe5020) |
| [actions/upload-artifact](https://github.com/actions/upload-artifact) | [v7.0.1 release](https://github.com/actions/upload-artifact/releases/tag/v7.0.1) | [`043fb46d`](https://github.com/actions/upload-artifact/commit/043fb46d1a93c77aae656e7c1c64a875d1fc6a0a) |
| [actions/download-artifact](https://github.com/actions/download-artifact) | [v8.0.1 release](https://github.com/actions/download-artifact/releases/tag/v8.0.1) | [`3e5f45b2`](https://github.com/actions/download-artifact/commit/3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c) |
| [GitHubSecurityLab/actions-permissions](https://github.com/GitHubSecurityLab/actions-permissions) | [v1 tag](https://github.com/GitHubSecurityLab/actions-permissions/tree/v1) | [`bf82d13b`](https://github.com/GitHubSecurityLab/actions-permissions/commit/bf82d13b9b10051d224345ab9184f5ede0a94289) |
| [1Password/load-secrets-action](https://github.com/1Password/load-secrets-action) | [v5 tag](https://github.com/1Password/load-secrets-action/tree/v5) | [`e544b780`](https://github.com/1Password/load-secrets-action/commit/e544b780808654ba8ceba5fb2fe2897103d92ff4) |
| [peter-evans/create-or-update-comment](https://github.com/peter-evans/create-or-update-comment) | [v5 tag](https://github.com/peter-evans/create-or-update-comment/tree/v5) | [`e8674b07`](https://github.com/peter-evans/create-or-update-comment/commit/e8674b075228eee787fea43ef493e45ece1004c9) |
| [mongodb/apix-action](https://github.com/mongodb/apix-action) | [v14 release](https://github.com/mongodb/apix-action/releases/tag/v14) | [`85491611`](https://github.com/mongodb/apix-action/commit/8549161120ce38b1e132ff833302a0ecbde58038) |
| [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain) | [stable branch](https://github.com/dtolnay/rust-toolchain/tree/stable) | [`4360b525`](https://github.com/dtolnay/rust-toolchain/commit/4360b52568e2003a75bf9bc1d59f33a8e3fc893c) |
| [mongodb/apix-action reusable workflows](https://github.com/mongodb/apix-action) | [main branch](https://github.com/mongodb/apix-action/tree/main) | [`9ce9e620`](https://github.com/mongodb/apix-action/commit/9ce9e6205a14af111352430e9f9adbea1c75230b) |

## Validation

- `git diff --check`
- `actionlint` passes after excluding pre-existing expression diagnostics unrelated to this change
- 1Password `v5` verified through annotated tag object to commit [`e544b780`](https://github.com/1Password/load-secrets-action/commit/e544b780808654ba8ceba5fb2fe2897103d92ff4)