### PR TITLE
fix(sync): write JSON separately

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -64,7 +64,7 @@ jobs:
           WORKFLOW_DIRECTORY: .github/workflows
         run: |
           chmod +x bin/sync
-          bin/sync --json > "$SYNC_JSON_FILE"
+          bin/sync --json "$SYNC_JSON_FILE"
       - name: Upload created PRs
         if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/sync/src/args.rs
+++ b/sync/src/args.rs
@@ -23,9 +23,9 @@ pub struct Args {
     #[arg(long, env = "SYNC_OWNER")]
     pub owner: Option<String>,
 
-    /// Print created pull requests as JSON.
-    #[arg(long)]
-    pub json: bool,
+    /// Write created pull requests as JSON to a file.
+    #[arg(long, value_name = "FILE")]
+    pub json: Option<PathBuf>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -55,5 +55,24 @@ impl Args {
         Ok(env::current_dir()
             .context("reading working directory")?
             .join(".github/workflows"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::Args;
+
+    #[test]
+    fn json_accepts_output_path() {
+        // Safe: arguments are compile-time test literals.
+        let args =
+            Args::try_parse_from(["sync", "--json", "results.json"]).expect("valid CLI arguments");
+
+        assert_eq!(
+            args.json.as_deref(),
+            Some(std::path::Path::new("results.json"))
+        );
     }
 }

--- a/sync/src/main.rs
+++ b/sync/src/main.rs
@@ -20,6 +20,7 @@ mod sync_entry;
 async fn main() -> Result<()> {
     // Set up logging
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(
             EnvFilter::builder()
                 .with_default_directive(tracing::Level::INFO.into())
@@ -93,8 +94,10 @@ async fn main() -> Result<()> {
 
     // Close old `apix-action` PRs, then commit, push, and open replacement PRs.
     let pull_requests = prs::create(repositories_needing_pr, targets_directory, token).await?;
-    if args.json {
-        println!("{}", serde_json::to_string_pretty(&pull_requests)?);
+    if let Some(path) = args.json {
+        let json = serde_json::to_string_pretty(&pull_requests)?;
+        std::fs::write(&path, json)
+            .with_context(|| format!("writing pull request results to {}", path.display()))?;
     }
 
     Ok(())


### PR DESCRIPTION
Fix sync workflow JSON output corruption.

- Send tracing logs to stderr.
- Make --json accept output filename and write directly.
- Update workflow invocation.

Tests: cargo fmt --all; cargo clippy --all-targets; cargo test --all-targets.