### PR TITLE
feat: create apix-bot signed commits

### DIFF
--- a/sync/Cargo.lock
+++ b/sync/Cargo.lock
@@ -1962,6 +1962,7 @@ name = "sync"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "clap",
  "git2",
  "non-empty-string",

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -5,7 +5,8 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1.0.104"
-clap = { version = "4.6.4", features = ["env", "derive"] }
+base64 = "0.22.1"
+clap ={ version = "4.6.4", features = ["env", "derive"] }
 git2 = { version = "0.21.0", features = ["https"] }
 non-empty-string = "0.2.6"
 nutype = "0.7.0"

--- a/sync/src/prs.rs
+++ b/sync/src/prs.rs
@@ -4,11 +4,10 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use anyhow::{Context, Result};
-use git2::{
-    Cred, IndexAddOption, PushOptions, RemoteCallbacks, Repository, Signature, StatusOptions,
-};
-use octocrab::{Octocrab, models::IssueState, params};
+use anyhow::{Context, Result, bail};
+use base64::{Engine, engine::general_purpose::STANDARD};
+use git2::{Repository, Status, StatusOptions};
+use octocrab::{Octocrab, models::IssueState, params, params::repos::Reference};
 use redacted::FullyRedacted;
 use serde::{Deserialize, Serialize};
 use tracing::info;
@@ -17,6 +16,29 @@ use crate::shared::{GithubToken, Repo};
 
 const LABEL: &str = "apix-action";
 const TITLE: &str = "ci: apix-action updates";
+
+// Commits created through this mutation are signed by GitHub, so they show up as verified.
+const CREATE_COMMIT: &str = "
+mutation (
+  $repository: String!,
+  $branch: String!,
+  $expectedHeadOid: GitObjectID!,
+  $message: String!,
+  $additions: [FileAddition!]!,
+  $deletions: [FileDeletion!]!
+) {
+  createCommitOnBranch(input: {
+    branch: {repositoryNameWithOwner: $repository, branchName: $branch},
+    expectedHeadOid: $expectedHeadOid,
+    message: {headline: $message},
+    fileChanges: {additions: $additions, deletions: $deletions}
+  }) {
+    commit {
+      oid
+      signature { wasSignedByGitHub }
+    }
+  }
+}";
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CreatedPullRequest {
@@ -62,12 +84,14 @@ pub async fn create(
                 repository.owner, repository.repository
             )
         })?;
-        let base = publish_changes(&path, &branch, &token).with_context(|| {
-            format!(
-                "publishing changes for {}/{}",
-                repository.owner, repository.repository
-            )
-        })?;
+        let base = publish_changes(&github, &repository, &path, &branch)
+            .await
+            .with_context(|| {
+                format!(
+                    "publishing changes for {}/{}",
+                    repository.owner, repository.repository
+                )
+            })?;
 
         let pull_request = github
             .pulls(repository.owner.as_str(), repository.repository.as_str())
@@ -172,8 +196,8 @@ pub fn summary_directory(directory: impl AsRef<Path>) -> Result<String> {
     summary(&files)
 }
 
-// Read statuses before publish_changes commits them.
-fn changed_workflows(path: &Path) -> Result<Vec<String>> {
+// List the changed paths of a checkout, along with how each one changed.
+fn statuses(path: &Path) -> Result<Vec<(String, Status)>> {
     let repository = Repository::open(path).context("opening repository")?;
     let mut options = StatusOptions::new();
     options
@@ -181,16 +205,30 @@ fn changed_workflows(path: &Path) -> Result<Vec<String>> {
         .recurse_untracked_dirs(true)
         .exclude_submodules(true);
 
-    let statuses = repository.statuses(Some(&mut options))?;
-    let mut actions = Vec::new();
-    for status in statuses.iter() {
-        let path = status.path().context("reading changed path")?;
-        if let Some(path) = path.strip_prefix(".github/workflows/") {
-            actions.push(path.to_owned());
-        }
-    }
+    repository
+        .statuses(Some(&mut options))?
+        .iter()
+        .map(|status| {
+            Ok((
+                status.path().context("reading changed path")?.to_owned(),
+                status.status(),
+            ))
+        })
+        .collect()
+}
+
+// Read statuses before publish_changes commits them.
+fn changed_workflows(path: &Path) -> Result<Vec<String>> {
+    let mut actions = statuses(path)?
+        .into_iter()
+        .filter_map(|(path, _)| {
+            path.strip_prefix(".github/workflows/")
+                .map(|path| path.to_owned())
+        })
+        .collect::<Vec<_>>();
     actions.sort();
     actions.dedup();
+
     Ok(actions)
 }
 
@@ -248,60 +286,141 @@ async fn close_labeled_pull_requests(github: &Octocrab, repository: &Repo) -> Re
     Ok(())
 }
 
-// Commit current generated files on a branch and push it to origin.
-fn publish_changes(
-    path: &Path,
-    branch: &str,
-    token: &FullyRedacted<GithubToken>,
-) -> Result<String> {
+// Working tree changes, encoded the way `createCommitOnBranch` expects them.
+#[derive(Debug, Default, Serialize)]
+struct FileChanges {
+    additions: Vec<FileAddition>,
+    deletions: Vec<FileDeletion>,
+}
+
+#[derive(Debug, Serialize)]
+struct FileAddition {
+    path: String,
+    /// Base64-encoded file contents, as required by the GraphQL schema.
+    contents: String,
+}
+
+#[derive(Debug, Serialize)]
+struct FileDeletion {
+    path: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateCommit {
+    #[serde(rename = "createCommitOnBranch")]
+    create_commit_on_branch: CreatedCommit,
+}
+
+#[derive(Debug, Deserialize)]
+struct CreatedCommit {
+    commit: CommitDetails,
+}
+
+#[derive(Debug, Deserialize)]
+struct CommitDetails {
+    oid: String,
+    signature: Option<CommitSignature>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CommitSignature {
+    #[serde(rename = "wasSignedByGitHub")]
+    was_signed_by_github: bool,
+}
+
+// Read the current branch and commit of a checkout.
+fn head(path: &Path) -> Result<(String, String)> {
     let repository = Repository::open(path).context("opening repository")?;
-    let base = repository
-        .head()
-        .context("reading repository HEAD")?
+    let reference = repository.head().context("reading repository HEAD")?;
+    let branch = reference
         .shorthand()
         .context("repository has detached HEAD")?
         .to_owned();
-    let commit = repository
-        .head()
-        .context("reading repository HEAD")?
+    let commit = reference
         .peel_to_commit()
-        .context("resolving repository HEAD")?;
+        .context("resolving repository HEAD")?
+        .id()
+        .to_string();
 
-    // Commit generated files on a fresh branch, then push it for the PR.
-    repository.branch(branch, &commit, false)?;
-    repository.set_head(&format!("refs/heads/{branch}"))?;
-    repository.checkout_head(None)?;
+    Ok((branch, commit))
+}
 
-    let mut index = repository.index()?;
-    index.add_all(["*"], IndexAddOption::DEFAULT, None)?;
-    index.write()?;
-    let tree = repository.find_tree(index.write_tree()?)?;
-    let signature = Signature::now("apix-action", "apix-action@mongodb.com")?;
-    repository.commit(
-        Some("HEAD"),
-        &signature,
-        &signature,
-        TITLE,
-        &tree,
-        &[&commit],
-    )?;
+// Turn the working tree changes into a GraphQL file change set.
+fn file_changes(path: &Path) -> Result<FileChanges> {
+    let mut changes = FileChanges::default();
+    for (file, status) in statuses(path)? {
+        if status.intersects(Status::WT_DELETED | Status::INDEX_DELETED) {
+            changes.deletions.push(FileDeletion { path: file });
+            continue;
+        }
 
-    let mut callbacks = RemoteCallbacks::new();
-    callbacks
-        .credentials(|_, _, _| Cred::userpass_plaintext("x-access-token", token.expose_secret()));
-    callbacks.push_update_reference(|reference, status| {
-        status.map_or(Ok(()), |status| {
-            Err(git2::Error::from_str(&format!(
-                "GitHub rejected push for {reference}: {status}"
-            )))
-        })
-    });
-    let mut options = PushOptions::new();
-    options.remote_callbacks(callbacks);
-    repository.find_remote("origin")?.push(
-        &[format!("refs/heads/{branch}:refs/heads/{branch}")],
-        Some(&mut options),
-    )?;
+        let contents = fs::read(path.join(&file))
+            .with_context(|| format!("reading changed file {file}"))
+            .map(|contents| STANDARD.encode(contents))?;
+        changes.additions.push(FileAddition {
+            path: file,
+            contents,
+        });
+    }
+    changes
+        .additions
+        .sort_by(|left, right| left.path.cmp(&right.path));
+    changes
+        .deletions
+        .sort_by(|left, right| left.path.cmp(&right.path));
+
+    Ok(changes)
+}
+
+// Commit generated files remotely so that GitHub signs the commit, and return the base branch.
+async fn publish_changes(
+    github: &Octocrab,
+    repository: &Repo,
+    path: &Path,
+    branch: &str,
+) -> Result<String> {
+    let owner = repository.owner.as_str();
+    let name = repository.repository.as_str();
+    let (base, expected_head) = head(path)?;
+    let changes = file_changes(path)?;
+    if changes.additions.is_empty() && changes.deletions.is_empty() {
+        bail!("no changes to commit in {owner}/{name}");
+    }
+
+    // `createCommitOnBranch` only commits onto an existing branch, so branch off the base first.
+    github
+        .repos(owner, name)
+        .create_ref(&Reference::Branch(branch.to_owned()), &expected_head)
+        .await
+        .with_context(|| format!("creating branch {branch} in {owner}/{name}"))?;
+
+    let commit: CreateCommit = github
+        .graphql(&serde_json::json!({
+            "query": CREATE_COMMIT,
+            "variables": {
+                "repository": format!("{owner}/{name}"),
+                "branch": branch,
+                "expectedHeadOid": expected_head,
+                "message": TITLE,
+                "additions": changes.additions,
+                "deletions": changes.deletions,
+            }
+        }))
+        .await
+        .with_context(|| format!("creating commit on {branch} in {owner}/{name}"))?;
+    let commit = commit.create_commit_on_branch.commit;
+
+    // A commit that GitHub did not sign would show up as unverified, which defeats the purpose.
+    if !commit
+        .signature
+        .is_some_and(|signature| signature.was_signed_by_github)
+    {
+        bail!(
+            "commit {} in {owner}/{name} was not signed by GitHub",
+            commit.oid
+        );
+    }
+    info!(repository = %format_args!("{owner}/{name}"), commit = %commit.oid, "signed commit created");
 
     Ok(base)
 }
@@ -312,7 +431,9 @@ mod tests {
 
     use anyhow::Result;
 
-    use super::{CreatedPullRequest, changed_workflows, description, summary_directory};
+    use super::{
+        CreatedPullRequest, changed_workflows, description, file_changes, summary_directory,
+    };
 
     #[test]
     fn description_lists_changed_actions() {
@@ -364,6 +485,52 @@ mod tests {
         assert_eq!(
             changed_workflows(&root)?,
             vec!["dependabot-auto-merge.yaml"]
+        );
+
+        fs::remove_dir_all(root)?;
+        Ok(())
+    }
+
+    #[test]
+    fn file_changes_encodes_additions_and_lists_deletions() -> Result<()> {
+        let unique = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)?
+            .as_nanos();
+        let root =
+            std::env::temp_dir().join(format!("apix-changes-{}-{unique}", std::process::id()));
+        let workflows = root.join(".github/workflows");
+        fs::create_dir_all(&workflows)?;
+        fs::write(workflows.join("removed.yaml"), "removed")?;
+
+        // Commit one workflow so that removing it later shows up as a deletion.
+        let repository = git2::Repository::init(&root)?;
+        let mut index = repository.index()?;
+        index.add_all(["*"], git2::IndexAddOption::DEFAULT, None)?;
+        index.write()?;
+        let tree = repository.find_tree(index.write_tree()?)?;
+        let signature = git2::Signature::now("test", "test@example.com")?;
+        repository.commit(Some("HEAD"), &signature, &signature, "initial", &tree, &[])?;
+
+        fs::remove_file(workflows.join("removed.yaml"))?;
+        fs::write(workflows.join("added.yaml"), "added")?;
+
+        let changes = file_changes(&root)?;
+        assert_eq!(
+            changes
+                .additions
+                .iter()
+                .map(|addition| (addition.path.as_str(), addition.contents.as_str()))
+                .collect::<Vec<_>>(),
+            // "added" base64-encoded.
+            vec![(".github/workflows/added.yaml", "YWRkZWQ=")]
+        );
+        assert_eq!(
+            changes
+                .deletions
+                .iter()
+                .map(|deletion| deletion.path.as_str())
+                .collect::<Vec<_>>(),
+            vec![".github/workflows/removed.yaml"]
         );
 
         fs::remove_dir_all(root)?;


### PR DESCRIPTION
## Summary

_Jira ticket_: [CLOUDP-439027](https://jira.mongodb.org/browse/CLOUDP-439027)

Makes the commits that `sync` creates in target repositories GitHub-verified. They are now created with the GraphQL `createCommitOnBranch` mutation, which GitHub signs with its own key, instead of a local `git commit` + `git push`.